### PR TITLE
Fix: image markdown couldn't able to deserialize due it's not implemented

### DIFF
--- a/packages/plugins/image/src/plugin/index.tsx
+++ b/packages/plugins/image/src/plugin/index.tsx
@@ -91,6 +91,34 @@ const Image = new YooptaPlugin<ImageElementMap, ImagePluginOptions>({
       serialize: (element, text) => {
         return `![${element.props.alt}](${element.props.src})\n`;
       },
+      deserialize: {
+        parse: (markdown) => {
+          const imageRegex = /!\[(.*?)\]\((.*?)\)/;
+          const match = imageRegex.exec(markdown);
+          if (match) {
+            const [_, alt, src] = match;
+            const sizes = { width: 650, height: 500 };
+
+            const props: SlateElement<'image', ImageElementProps>['props'] = {
+              nodeType: 'void',
+              src,
+              alt,
+              srcSet: '',
+              fit: 'contain',
+              sizes,
+            };
+
+            const node: SlateElement = {
+              id: generateId(),
+              type: 'image',
+              children: [{ text: '' }],
+              props,
+            };
+
+            return node;
+          }
+        },
+      },
     },
     email: {
       serialize: (element, text, blockMeta) => {


### PR DESCRIPTION
## Description

If we try to `deserialize` the image with it's markdown syntax like as given below
```js
const content = markdown.deserialize(editor, "![Sonny and Mariel high fiving.](https://content.codecademy.com/courses/learn-cpp/community-challenge/highfive.gif)");
editor.setEditorValue(content);
console.log(content);
```
It could not able to convert it into it's respective image component/render.


Fixes # (issue)
Adding this `deserialize` method so that it can be envoked for `image` component during this export method for markdown export. 

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
