### PR TITLE
fix: image markdown couldn't able to deserialize due it's not implemented

### DIFF
--- a/packages/core/exports/src/markdown/deserialize.ts
+++ b/packages/core/exports/src/markdown/deserialize.ts
@@ -3,6 +3,30 @@ import { marked } from 'marked';
 import { deserializeHTML } from '../html/deserialize';
 
 export function deserializeMarkdown(editor: YooEditor, markdown: string): YooptaContentValue {
+  const imageExtension = {
+	  name: 'image',
+	  level: 'block',
+	  start(src: string) {
+		  return src.match(/!\[/)?.index;
+	  },
+	  tokenizer(src: string) {
+		  const rule = /^!\[(.*?)\]\((.*?)\)/;
+		  const match = rule.exec(src);
+		  if (match) {
+			  return {
+				  type: 'image',
+				  raw: match[0],
+				  alt: match[1],
+				  href: match[2]
+			  };
+		  }
+		  return;
+	  },
+	  renderer(token: any) {
+		  return `<img alt="${token.alt}" src="${token.href}">`;
+	  }
+  };
+  marked.use({ extensions: [imageExtension] });
   const html = marked.parse(markdown, { gfm: true, breaks: true, pedantic: false }) as string;
   return deserializeHTML(editor, html);
 }


### PR DESCRIPTION
## Description

If we try to `deserialize` the image with it's markdown syntax like as given below
```js
const content = markdown.deserialize(editor, "![Sonny and Mariel high fiving.](https://content.codecademy.com/courses/learn-cpp/community-challenge/highfive.gif)");
editor.setEditorValue(content);
console.log(content);
```
It could not able to convert it into it's respective image component/render.
Issue is with the marked, cause this library parse this image syntax and convert it to sometime like this

```markdown
![Alt text](url)
```
above markdown converts to this image tag with wrapped inside p tag.
```html
<p><img src="url" atl="Alt text"/></p>
```

that's why yoopta-editor can't able to parse the image tag markdown and render it to ImageRender component. 

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
