### PR TITLE
fix: click on placeholder adds focus to block

### DIFF
--- a/packages/core/editor/src/styles.css
+++ b/packages/core/editor/src/styles.css
@@ -32,6 +32,8 @@
   padding-left: 5px;
   font-weight: inherit;
   font-style: inherit;
+  pointer-events: none;
+  cursor: text;
 }
 
 /* common */


### PR DESCRIPTION
## Description

When clicking on the placeholder ("Type '/' for commands") the Block didn't gain focus. This is because the placeholder is a pseudo-element that was blocking the click event.

This change fixes it.

Fixes # (issue)

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Screenshots:

### Before:

https://github.com/user-attachments/assets/cf04d854-13be-4eee-9d47-f70e08611168

### After:
https://github.com/user-attachments/assets/d9de7606-771e-4623-b90a-f589ad7d320a

