### PR TITLE
fix: align callout icon with text

### DIFF
--- a/packages/plugins/callout/src/styles.css
+++ b/packages/plugins/callout/src/styles.css
@@ -14,7 +14,11 @@
 }
 
 .yoopta-callout-icon {
-  @apply yoo-callout-mt-1.5 yoo-callout-w-4 yoo-callout-absolute yoo-callout-left-4 yoo-callout-top-2
+  @apply yoo-callout-w-4 yoo-callout-absolute yoo-callout-left-4 yoo-callout-top-1/2
+}
+
+.yoopta-callout-icon>svg {
+  @apply -yoo-callout-translate-y-1/2
 }
 
 .yoopta-callout-theme-default {


### PR DESCRIPTION
## Description

This change adjusts the positioning of .yoopta-callout-icon to better align it vertically. The top-2 utility has been replaced with top-1/2, centering the element within its parent. Additionally, a new rule for .yoopta-callout-icon > svg applies -translate-y-1/2, ensuring that the icon itself is vertically centered within its container.

This does not work for the info icon since the path doesn't fill the 16x16 block all other icons on callout do

Fixes # (issue)

Misalignment of the callout icon

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
