### PR TITLE
extend [Image|Video|File]PluginOptions  with onError

### DIFF
--- a/packages/plugins/file/src/types.ts
+++ b/packages/plugins/file/src/types.ts
@@ -14,6 +14,7 @@ export type FileUploadResponse = Partial<FileElementProps> & { src: string };
 
 export type FilePluginOptions = {
   onUpload?: (file: File) => Promise<FileUploadResponse>;
+  onError?: (error: any) => void;
   accept?: string;
 };
 

--- a/packages/plugins/file/src/ui/FileUploader.tsx
+++ b/packages/plugins/file/src/ui/FileUploader.tsx
@@ -33,6 +33,7 @@ const FileUploader = ({ accept = '', onClose, blockId, onSetLoading }: Props) =>
         },
       });
     } catch (error) {
+      options?.onError?.(error);
     } finally {
       onSetLoading(false);
     }

--- a/packages/plugins/image/src/types.ts
+++ b/packages/plugins/image/src/types.ts
@@ -26,6 +26,7 @@ export type ImageOptimizationFields = {
 
 export type ImagePluginOptions = {
   onUpload: (file: File) => Promise<ImageUploadResponse>;
+  onError?: (error: any) => void;
   accept?: string;
   optimizations?: ImageOptimizationFields;
   maxSizes?: {

--- a/packages/plugins/image/src/ui/FileUploader.tsx
+++ b/packages/plugins/image/src/ui/FileUploader.tsx
@@ -42,6 +42,7 @@ const FileUploader = ({ accept = 'image/*', onClose, blockId, onSetLoading }: Pr
         },
       });
     } catch (error) {
+      options?.onError?.(error);
     } finally {
       onSetLoading(false);
     }

--- a/packages/plugins/video/src/types.ts
+++ b/packages/plugins/video/src/types.ts
@@ -38,6 +38,7 @@ export type VideoUploadResponse = Omit<VideoElementProps, 'srcSet'>;
 export type VideoPluginOptions = {
   onUpload: (file: File) => Promise<VideoUploadResponse>;
   onUploadPoster?: (file: File) => Promise<string>;
+  onError?: (error: any) => void;
   accept?: string;
   maxSizes?: {
     maxWidth?: number | string;

--- a/packages/plugins/video/src/ui/FileUploader.tsx
+++ b/packages/plugins/video/src/ui/FileUploader.tsx
@@ -43,6 +43,7 @@ const FileUploader = ({ accept = 'video/*', onClose, blockId, onSetLoading }: Pr
         },
       });
     } catch (error) {
+      options?.onError?.(error);
     } finally {
       onSetLoading(false);
     }


### PR DESCRIPTION
## Description

Currently on upload any error is silent and a user does not know what happened.

Fixes # [issue](https://github.com/yoopta-editor/Yoopta-Editor/issues/464)

## Type of change

Please tick the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
