### PR TITLE
[Fix]: Safari event handling issues

### DIFF
--- a/packages/core/editor/src/UI/BlockOptions/BlockOptions.tsx
+++ b/packages/core/editor/src/UI/BlockOptions/BlockOptions.tsx
@@ -69,29 +69,42 @@ const BlockOptions = ({ isOpen, onClose, refs, style, actions = DEFAULT_ACTIONS,
   const rootElement = getRootBlockElement(editor.blocks[currentBlock?.type || '']?.elements);
   const isVoidElement = rootElement?.props?.nodeType === 'void';
 
-  const onDelete = () => {
-    editor.deleteBlock({ at: editor.path.current });
-    editor.setPath({ current: null });
+  const onDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
 
+    const currentBlock = findPluginBlockByPath(editor, { at: editor.path.current });
+    if (!currentBlock) {
+      console.warn('Cannot delete block: no current block found');
+      onClose();
+      return;
+    }
+
+    editor.deleteBlock({ at: currentBlock.meta.order });
+    editor.setPath({ current: null });
     onClose();
   };
 
-  const onDuplicate = () => {
+  const onDuplicate = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
     // [TEST]
     if (typeof editor.path.current !== 'number') return;
 
     editor.duplicateBlock({ original: { path: editor.path.current }, focus: true });
-
     onClose();
   };
 
-  const onCopy = () => {
+  const onCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
     const block = findPluginBlockByPath(editor);
     if (block) {
       copy(`${window.location.origin}${window.location.pathname}#${block.id}`);
       editor.emit('block:copy', block);
     }
-
     onClose();
   };
 

--- a/packages/core/editor/src/components/Block/FloatingBlockActions.tsx
+++ b/packages/core/editor/src/components/Block/FloatingBlockActions.tsx
@@ -164,23 +164,22 @@ export const FloatingBlockActions = memo(({ editor, dragHandleProps }: FloatingB
     if (!block) return;
 
     const slate = findSlateBySelectionPath(editor, { at: block.meta.order });
-    editor.focusBlock(block.id);
-
     if (!slate) return;
 
-    setTimeout(() => {
-      const currentBlock = editor.blocks[block.type];
+    // Set path immediately
+    editor.setPath({ current: block.meta.order, selected: [block.meta.order] });
 
-      if (!currentBlock.hasCustomEditor) {
-        ReactEditor.blur(slate);
-        ReactEditor.deselect(slate);
-        Transforms.deselect(slate);
-      }
+    // Then focus and open options
+    editor.focusBlock(block.id);
 
-      editor.setPath({ current: block.meta.order, selected: [block.meta.order] });
+    const currentBlock = editor.blocks[block.type];
+    if (!currentBlock.hasCustomEditor) {
+      ReactEditor.blur(slate);
+      ReactEditor.deselect(slate);
+      Transforms.deselect(slate);
+    }
 
-      setIsBlockOptionsOpen(true);
-    }, 10);
+    setIsBlockOptionsOpen(true);
   };
 
   const onDragButtonRef = (node: HTMLElement | null) => {

--- a/packages/core/editor/src/editor/core/applyTransforms.ts
+++ b/packages/core/editor/src/editor/core/applyTransforms.ts
@@ -362,7 +362,6 @@ const MAX_HISTORY_LENGTH = 100;
 export function applyTransforms(editor: YooEditor, ops: YooptaOperation[], options?: ApplyTransformsOptions): void {
   editor.children = createDraft(editor.children);
   editor.path = createDraft(editor.path);
-
   const { validatePaths = true, source } = options || {};
   const operations = [...ops];
 

--- a/packages/tools/toolbar/src/components/Toolbar.tsx
+++ b/packages/tools/toolbar/src/components/Toolbar.tsx
@@ -11,6 +11,7 @@ const Toolbar = ({ render }: ToolbarToolProps) => {
   const editor = useYooptaEditor();
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const [hold, setHold] = useState(false);
+  const [currDomSelection, setDomSelection] = useState<Selection | null>(null);
 
   const { refs, floatingStyles, context } = useFloating({
     placement: 'top',
@@ -28,6 +29,18 @@ const Toolbar = ({ render }: ToolbarToolProps) => {
     if (hold) return;
 
     const domSelection = window.getSelection();
+
+    // Add check for toolbar click
+    const toolbarElement = refs.floating.current;
+    if (toolbarElement && toolbarElement.contains(document.activeElement)) {
+      return;
+    }
+
+    if (domSelection?.anchorNode === null && currDomSelection?.anchorNode !== null) {
+      return;
+    }
+
+    setDomSelection(domSelection);
 
     if (!domSelection || domSelection?.isCollapsed || domSelection?.anchorOffset === domSelection?.focusOffset) {
       return setIsToolbarOpen(false);


### PR DESCRIPTION
## Description

Fixing some issues for Safari that we found in our fork:

* Action Menu now stays open when clicking into actions that have further options
* Block Actions now function without erroring

Both of these fixes are handled by prevent default and stop propagation, as Safari handles the timing of click events differently from most browsers.

Fixes # (issue)

## Type of change

Please tick the relevant option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
