### PR TITLE
fix issue: when there are two or more inline elements

### DIFF
--- a/packages/core/editor/src/plugins/hooks.ts
+++ b/packages/core/editor/src/plugins/hooks.ts
@@ -33,16 +33,17 @@ export const useSlateEditor = (
       const isVoid = nodeType === 'void';
       const isInlineVoid = nodeType === 'inlineVoid';
 
+      const { markableVoid: prevMarkableVoid, isVoid: prevIsVoid, isInline: prevIsInline } = slate;
       if (isInlineVoid) {
-        slate.markableVoid = (element) => element.type === elementType;
+        slate.markableVoid = (element) => prevMarkableVoid(element) || element.type === elementType;
       }
 
       if (isVoid || isInlineVoid) {
-        slate.isVoid = (element) => element.type === elementType;
+        slate.isVoid = (element) => prevIsVoid(element) || element.type === elementType;
       }
 
       if (isInline || isInlineVoid) {
-        slate.isInline = (element) => element.type === elementType;
+        slate.isInline = (element) => prevIsInline(element) || element.type === elementType;
 
         // [TODO] - Move it to Link plugin extension
         slate = withInlines(editor, slate);


### PR DESCRIPTION

## Description

Currently, when there are two or more inline elements, only the last element will be treat as inline, and others will be treat as blocks. In the other words, only one inline plugin can exist. For example, when I use both mention(inlineVoid) and link(inline) element, the mention element cannot be inserted in a paragraph, cause it will be treat as a block element.

Fixes # (issue)

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
