### PR TITLE
fix(editor): Fixed events for multiple editors by making them not global

### DIFF
--- a/packages/core/editor/src/editor/index.tsx
+++ b/packages/core/editor/src/editor/index.tsx
@@ -27,16 +27,16 @@ import { UndoRedoOptions, YooptaHistory } from './core/history';
 import EventEmitter from 'eventemitter3';
 import { getEmail, EmailTemplateOptions } from '../parsers/getEmail';
 
-const eventEmitter = new EventEmitter();
-
-const Events = {
-  on: (event, fn) => eventEmitter.on(event, fn),
-  once: (event, fn) => eventEmitter.once(event, fn),
-  off: (event, fn) => eventEmitter.off(event, fn),
-  emit: (event, payload) => eventEmitter.emit(event, payload),
-};
-
 export function createYooptaEditor(): YooEditor {
+  // Create a unique event emitter for each editor instance
+  const eventEmitter = new EventEmitter();
+  
+  const Events = {
+    on: (event, fn) => eventEmitter.on(event, fn),
+    once: (event, fn) => eventEmitter.once(event, fn),
+    off: (event, fn) => eventEmitter.off(event, fn),
+    emit: (event, payload) => eventEmitter.emit(event, payload),
+  };
   const editor: YooEditor = {
     id: '',
     children: {},


### PR DESCRIPTION
## Description

https://github.com/yoopta-editor/Yoopta-Editor/issues/466
> 
When there are multiple instances of the YooptaEditor the onChange event is triggered for all instances with the same value AND

 Also if you perform undo redo actions with ctrl+z and ctrl+y they are applied for all editor instances not only for the focused one (WIP)

Fixes # (issue)

I have made it such that the editors have their own local events instead of global and now callbacks are local per editor instantiation.

## Type of change

Please tick the relevant option.

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ X I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X]  I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
