### PR TITLE
fix(ui): buffer IME composition in ElementOptions.Input

### DIFF
--- a/.changeset/ime-element-options-input.md
+++ b/.changeset/ime-element-options-input.md
@@ -1,0 +1,5 @@
+---
+"@yoopta/ui": patch
+---
+
+Keep IME composition in ElementOptions.Input until compositionend so CJK input is not committed mid-composition.

--- a/packages/core/ui/src/element-options/components/element-options-input.test.tsx
+++ b/packages/core/ui/src/element-options/components/element-options-input.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ElementOptionsInput } from './element-options-input';
+
+describe('ElementOptionsInput IME composition', () => {
+  it('does not call onChange with intermediate IME characters', () => {
+    const onChange = vi.fn();
+    render(<ElementOptionsInput value="" onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'ㄇ' } });
+    fireEvent.change(input, { target: { value: 'ㄇㄨ' } });
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: '木' } });
+    fireEvent.compositionEnd(input);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('木');
+  });
+
+  it('shows intermediate IME characters without committing them to a controlled parent', () => {
+    const committed: string[] = [];
+
+    function ControlledInput() {
+      const [value, setValue] = useState('');
+      return (
+        <ElementOptionsInput
+          value={value}
+          onChange={(next) => {
+            committed.push(next);
+            setValue(next);
+          }}
+        />
+      );
+    }
+
+    render(<ControlledInput />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'ㄇ' } });
+
+    expect(committed).toEqual([]);
+    expect(input.value).toBe('ㄇ');
+
+    fireEvent.change(input, { target: { value: 'ㄇㄨ' } });
+    expect(committed).toEqual([]);
+    expect(input.value).toBe('ㄇㄨ');
+
+    fireEvent.change(input, { target: { value: '木' } });
+    fireEvent.compositionEnd(input);
+
+    expect(committed).toEqual(['木']);
+    expect(input.value).toBe('木');
+  });
+
+  it('does not overwrite in-progress IME composition when the parent value is stale', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<ElementOptionsInput value="" onChange={onChange} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'ㄇ' } });
+
+    rerender(<ElementOptionsInput value="" onChange={onChange} />);
+
+    expect(input.value).toBe('ㄇ');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onChange immediately for non-IME typing', () => {
+    const onChange = vi.fn();
+    render(<ElementOptionsInput value="" onChange={onChange} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('hello');
+  });
+
+  it('syncs from the value prop when not composing', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<ElementOptionsInput value="Title" onChange={onChange} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('Title');
+
+    rerender(<ElementOptionsInput value="Updated" onChange={onChange} />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('Updated');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/ui/src/element-options/components/element-options-input.tsx
+++ b/packages/core/ui/src/element-options/components/element-options-input.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 import type { ElementOptionsInputProps } from '../types';
 
 export const ElementOptionsInput = ({
@@ -8,8 +10,32 @@ export const ElementOptionsInput = ({
   className,
   style,
 }: ElementOptionsInputProps) => {
+  const [localValue, setLocalValue] = useState(value);
+  const composingRef = useRef(false);
+
+  useEffect(() => {
+    if (!composingRef.current) {
+      setLocalValue(value);
+    }
+  }, [value]);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(e.target.value);
+    const nextValue = e.target.value;
+    setLocalValue(nextValue);
+    if (!composingRef.current) {
+      onChange(nextValue);
+    }
+  };
+
+  const handleCompositionStart = () => {
+    composingRef.current = true;
+  };
+
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    composingRef.current = false;
+    const nextValue = e.currentTarget.value;
+    setLocalValue(nextValue);
+    onChange(nextValue);
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -19,8 +45,10 @@ export const ElementOptionsInput = ({
   return (
     <input
       type={type}
-      value={value}
+      value={localValue}
       onChange={handleChange}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
       onMouseDown={handleMouseDown}
       placeholder={placeholder}
       className={className}


### PR DESCRIPTION
Fixes #591.

`ElementOptions.Input` is fully controlled, so CJK IME `onChange` events committed intermediate characters (Zhuyin, kana) before `compositionend`. Browsers expect the value to stay untouched during composition.

Buffer locally until `compositionend`. Latin typing still calls `onChange` immediately. Parent `value` updates still apply when not composing.